### PR TITLE
Upgrade to NS7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NativeScript AppSync  Test
+# NativeScript AppSync
 
 > ❤️ Built upon the shoulders of giants. Or more accurately, [Microsoft CodePush](https://github.com/microsoft/code-push)!
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NativeScript AppSync
+# NativeScript AppSync  Test
 
 > ❤️ Built upon the shoulders of giants. Or more accurately, [Microsoft CodePush](https://github.com/microsoft/code-push)!
 

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -219,6 +219,7 @@ export interface IReleaseNativeScriptCommand extends IReleaseBaseCommand {
     keystorePassword?: string;
     keystoreAlias?: string;
     keystoreAliasPassword?: string;
+    appResourcesPath?: string;
 }
 
 export interface IRollbackCommand extends ICommand {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1478,16 +1478,20 @@ export var releaseNativeScript = (command: cli.IReleaseNativeScriptCommand): Pro
                 throw new Error("Unable to find or read \"package.json\" in the CWD. The \"release\" command must be executed in a NativeScript project folder.");
             }
 
-            if (!projectPackageJson.nativescript) {
+            //ns 7 files
+            var projectRoot: string = process.cwd();
+            var tsConfig = path.join(projectRoot, 'nativescript.config.ts');
+            var jsConfig = path.join(projectRoot, 'nativescript.config.js');
+
+            if (!(fs.existsSync(tsConfig) || fs.existsSync(jsConfig) || projectPackageJson.nativescript)) {
                 throw new Error("The project in the CWD is not a NativeScript project.");
             }
 
             var platform: string = command.platform.toLowerCase();
-            var projectRoot: string = process.cwd();
             var platformFolder: string = path.join(projectRoot, "platforms", platform);
             var iOSFolder = path.basename(projectRoot).replace(/[-]+/g, ''); // removes dashes
             var outputFolder: string;
-            var appResourcesFolder: string = path.join(projectRoot, "app", "App_Resources");
+            var appResourcesFolder;
             var nsConfigPackageJson: any;
             try {
                 nsConfigPackageJson = require(path.join(process.cwd(), "nsconfig.json"));
@@ -1495,7 +1499,13 @@ export var releaseNativeScript = (command: cli.IReleaseNativeScriptCommand): Pro
                     appResourcesFolder = path.join(projectRoot, nsConfigPackageJson.appResourcesPath);
                 }
             } catch (ignore) {
-                // no nsconfig.json found, so using defaults for app and app_resources folders
+                // no nsconfig.json found, so ns7 project
+                // no easy way to find appResources folder so using defaults or rely on options paramter "appResourcesPath"
+                if(command.appResourcesPath) {
+                    appResourcesFolder = path.join(projectRoot,command.appResourcesPath);
+                } else {
+                    appResourcesFolder = path.join(projectRoot, "App_Resources")
+                }
             }
 
             if (platform === "ios") {
@@ -1516,7 +1526,13 @@ export var releaseNativeScript = (command: cli.IReleaseNativeScriptCommand): Pro
                 try {
                     which.sync(nativeScriptCLI);
                 } catch (e) {
-                    throw new Error(`Unable to run "${nativeScriptCLI} ${nativeScriptCommand}". Please ensure that the NativeScript CLI is installed.`);
+                    //try for ns7 or up
+                    try {
+                        nativeScriptCLI = "ns"
+                        which.sync(nativeScriptCLI);
+                    } catch(e) {
+                        throw new Error(`Unable to run "${nativeScriptCLI} ${nativeScriptCommand}". Please ensure that the NativeScript CLI is installed.`);
+                    }
                 }
 
                 var nativeScriptCommand: string = "build " + platform;

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1491,7 +1491,7 @@ export var releaseNativeScript = (command: cli.IReleaseNativeScriptCommand): Pro
             var platformFolder: string = path.join(projectRoot, "platforms", platform);
             var iOSFolder = path.basename(projectRoot).replace(/[-]+/g, ''); // removes dashes
             var outputFolder: string;
-            var appResourcesFolder;
+            var appResourcesFolder: string;
             var nsConfigPackageJson: any;
             try {
                 nsConfigPackageJson = require(path.join(process.cwd(), "nsconfig.json"));

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -476,7 +476,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("noDuplicateReleaseError", { default: false, demand: false, description: "When this flag is set, releasing a package that is identical to the latest release will produce a warning instead of an error", type: "boolean" })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in \"Info.plist\" (iOS) or \"AndroidManifest.xml\" (Android).", type: "string" })
-            .option("appResourcesPath", { alias: "a", default: "App_Resources", demand: false, description: "Specify the reletive path of the app resources from project root", type: "string" })
+            .option("appResourcesPath", { alias: "a", default: "App_Resources", demand: false, description: "Specify the relative path of the app resources from project root", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
 
         addCommonConfiguration(yargs);

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -476,6 +476,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("noDuplicateReleaseError", { default: false, demand: false, description: "When this flag is set, releasing a package that is identical to the latest release will produce a warning instead of an error", type: "boolean" })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in \"Info.plist\" (iOS) or \"AndroidManifest.xml\" (Android).", type: "string" })
+            .option("appResourcesPath", { alias: "a", default: "App_Resources", demand: false, description: "Specify the reletive path of the app resources from project root", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
 
         addCommonConfiguration(yargs);
@@ -919,6 +920,7 @@ function createCommand(): cli.ICommand {
                     releaseNativeScriptCommand.keystorePassword = argv["keystorePassword"];
                     releaseNativeScriptCommand.keystoreAlias = argv["keystoreAlias"];
                     releaseNativeScriptCommand.keystoreAliasPassword = argv["keystoreAliasPassword"];
+                    releaseNativeScriptCommand.appResourcesPath = argv["appResourcesPath"];
                 }
                 break;
 


### PR DESCRIPTION
Refers to https://github.com/NativeScript/nativescript-app-sync-sdk-cli/issues/7

Adds a new parameter for ns7 to specify the App Resources/IOS/Info.plist because the nativescript config does not exist anymore.
The new features do not affect ns6 compatibility.