### PR TITLE
ns7 fix

### DIFF
--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -219,6 +219,7 @@ export interface IReleaseNativeScriptCommand extends IReleaseBaseCommand {
     keystorePassword?: string;
     keystoreAlias?: string;
     keystoreAliasPassword?: string;
+    appResourcesPath?: string;
 }
 
 export interface IRollbackCommand extends ICommand {

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -476,6 +476,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("noDuplicateReleaseError", { default: false, demand: false, description: "When this flag is set, releasing a package that is identical to the latest release will produce a warning instead of an error", type: "boolean" })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in \"Info.plist\" (iOS) or \"AndroidManifest.xml\" (Android).", type: "string" })
+            .option("appResourcesPath", { alias: "a", default: "App_Resources", demand: false, description: "Specify the relative path of the app resources from project root", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
 
         addCommonConfiguration(yargs);
@@ -919,6 +920,7 @@ function createCommand(): cli.ICommand {
                     releaseNativeScriptCommand.keystorePassword = argv["keystorePassword"];
                     releaseNativeScriptCommand.keystoreAlias = argv["keystoreAlias"];
                     releaseNativeScriptCommand.keystoreAliasPassword = argv["keystoreAliasPassword"];
+                    releaseNativeScriptCommand.appResourcesPath = argv["appResourcesPath"];
                 }
                 break;
 


### PR DESCRIPTION
Refers to #7

Adds a new parameter for ns7 to specify the App Resources/IOS/Info.plist because the nativescript config does not exist anymore.
The new features do not affect ns6 compatibility.